### PR TITLE
Fix: Align Spotify API response with client expectation

### DIFF
--- a/code-ninja/src/app/api/spotify/now-playing/route.ts
+++ b/code-ninja/src/app/api/spotify/now-playing/route.ts
@@ -100,13 +100,11 @@ export async function GET(req: NextRequest) {
       }
 
       return NextResponse.json({
-        spotify: {
-          name: track.name,
-          artists: track.artists,
-          album: track.album,
-          external_urls: track.external_urls,
-          isPlaying: false,
-        },
+        name: track.name,
+        artists: track.artists,
+        album: track.album,
+        external_urls: track.external_urls,
+        isPlaying: false,
       });
     }
 
@@ -132,13 +130,11 @@ export async function GET(req: NextRequest) {
     }
 
     return NextResponse.json({
-      spotify: {
-        name: data.item.name,
-        artists: data.item.artists,
-        album: data.item.album,
-        external_urls: data.item.external_urls,
-        isPlaying: data.is_playing,
-      },
+      name: data.item.name,
+      artists: data.item.artists,
+      album: data.item.album,
+      external_urls: data.item.external_urls,
+      isPlaying: data.is_playing,
     });
   } catch (error) {
     console.error("Spotify API error:", error);


### PR DESCRIPTION
The API route for Spotify now-playing was returning track data nested under a 'spotify' key. The client-side component expected the track data directly at the root of the JSON response.

This commit modifies the API route to return the track data directly, resolving the mismatch and allowing the component to correctly display Spotify track information.