### PR TITLE
feat: Implement shared state for welcome screen

### DIFF
--- a/code-ninja/src/app/layout.tsx
+++ b/code-ninja/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { ThemeProvider } from "@/components/theme-provider";
+import { AppProvider } from "@/context/AppContext";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -49,16 +50,18 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.className} antialiased`}>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange={false}
-        >
-          {children}
-          <Analytics />
-          <SpeedInsights />
-        </ThemeProvider>
+        <AppProvider>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange={false}
+          >
+            {children}
+            <Analytics />
+            <SpeedInsights />
+          </ThemeProvider>
+        </AppProvider>
       </body>
     </html>
   );

--- a/code-ninja/src/app/page.tsx
+++ b/code-ninja/src/app/page.tsx
@@ -1,16 +1,13 @@
 "use client";
 
-import { useState } from "react";
 import { AnimatePresence } from "framer-motion";
 import WelcomeScreen from "@/components/welcome/WelcomeScreen";
-
 import MainContent from "@/components/main-content";
 import MainLayout from "./(main)/layout";
-
-
+import { useAppContext } from "@/context/AppContext";
 
 export default function Page() {
-  const [showWelcome, setShowWelcome] = useState(true);
+  const { showWelcome, setShowWelcome } = useAppContext();
 
   const handleWelcomeComplete = () => {
     setShowWelcome(false);
@@ -20,9 +17,9 @@ export default function Page() {
     <main className="min-h-screen">
       <AnimatePresence mode="wait">
         {showWelcome ? (
-          <WelcomeScreen 
+          <WelcomeScreen
             key="welcome"
-            onComplete={handleWelcomeComplete} 
+            onComplete={handleWelcomeComplete}
           />
         ) : (
           <MainLayout>

--- a/code-ninja/src/context/AppContext.tsx
+++ b/code-ninja/src/context/AppContext.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface AppContextType {
+  showWelcome: boolean;
+  setShowWelcome: (show: boolean) => void;
+}
+
+const AppContext = createContext<AppContextType | undefined>(undefined);
+
+export function AppProvider({ children }: { children: ReactNode }) {
+  const [showWelcome, setShowWelcome] = useState(true);
+
+  return (
+    <AppContext.Provider value={{ showWelcome, setShowWelcome }}>
+      {children}
+    </AppContext.Provider>
+  );
+}
+
+export function useAppContext() {
+  const context = useContext(AppContext);
+  if (context === undefined) {
+    throw new Error("useAppContext must be used within an AppProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
This commit introduces a shared state for the welcome screen to ensure it is only displayed once per session.

- Created a new `AppContext` to manage the `showWelcome` state.
- Wrapped the main layout in the `AppProvider` to make the shared state available throughout the application.
- Updated the main page to use the shared state, preventing the welcome screen from being shown on every navigation to the home page.